### PR TITLE
Fix issue in CrudGeneratorCommand.php and CrudGeneratorEntity.php

### DIFF
--- a/src/Command/CrudGeneratorCommand.php
+++ b/src/Command/CrudGeneratorCommand.php
@@ -11,7 +11,9 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class CrudGeneratorCommand extends Command
 {
-    const COMMAND_VERSION = '0.21.0';
+    const COMMAND_VERSION = '0.22.0';
+
+    protected $container;
 
     public function __construct($app)
     {

--- a/src/Command/CrudGeneratorEntity.php
+++ b/src/Command/CrudGeneratorEntity.php
@@ -57,6 +57,6 @@ class CrudGeneratorEntity
         $this->list3 = substr_replace($this->list3, '', -8);
         $this->list4 = substr_replace($this->list4, '', -2);
         $this->list5 = substr_replace($this->list5, '', -9);
-        $this->list6 = substr_replace($this->list6, '', -14);
+        $this->list6 = substr_replace($this->list6 ?? '', '', -14);
     }
 }


### PR DESCRIPTION
- Fix deprecated dynamic property usage in CrudGeneratorCommand
- Fix deprecated error by handling null in substr_replace in CrudGeneratorEntity.php
